### PR TITLE
Corrected spelling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ were designed by Dan Bernstein and his collaborators, with the exception of
 the Blake2 hash function, which was designed by Jean-Philippe Aumasson.
 
 The design choices in NaCl, particularly in regard to the Curve25519
-Diffie-Hellman function, ephasize security (whereas [NIST curves emphasize
+Diffie-Hellman function, emphasize security (whereas [NIST curves emphasize
 "performance" at the cost of security][nist-security-dangers]), and "magic
 constants" in NaCl are picked by theorems designed to maximize security.
 The same cannot be said of NIST curves, where the specific origins of certain


### PR DESCRIPTION
Emphasize has an m :-)
